### PR TITLE
Tweak run.sh so that way it actually fails when it should

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 MOD_VERSION="$(cat gradle.properties | grep mod_version | cut -d '=' -f 2)"
 MC_VERSION="$(cat gradle.properties | grep minecraft_version | cut -d '=' -f 2)"


### PR DESCRIPTION
It does fail, but we need assurance. We don't know what shell someone is using.